### PR TITLE
chore: change pre-commit revision numbering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages:
   - commit
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 0161422b4e09b47536ea13f49e786eb3616fe0d7 # v2.4.0
+    rev: v2.4.0
     hooks:
       - id: no-commit-to-branch
       - id: trailing-whitespace
@@ -26,7 +26,7 @@ repos:
 #        language_version: python3
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: 2ba6564b82c125266091e2571563f7b957aec19c # 0.12.0
+    rev: v0.12.0
     hooks:
       - id: gitlint
         stages:

--- a/template-basic/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
+++ b/template-basic/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages:
   - commit
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 0161422b4e09b47536ea13f49e786eb3616fe0d7 # v2.4.0
+    rev: v2.4.0
     hooks:
       - id: no-commit-to-branch
       - id: trailing-whitespace
@@ -29,7 +29,7 @@ repos:
 
 {%- if cookiecutter.repository_enable_conventionalcommit == 'y' %}
   - repo: https://github.com/jorisroovers/gitlint
-    rev: 2ba6564b82c125266091e2571563f7b957aec19c # 0.12.0
+    rev: v0.12.0
     hooks:
       - id: gitlint
         stages:

--- a/template-python-click-app/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
+++ b/template-python-click-app/{{cookiecutter.repository_name}}/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages:
   - commit
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 0161422b4e09b47536ea13f49e786eb3616fe0d7 # v2.4.0
+    rev: v2.4.0
     hooks:
       - id: no-commit-to-branch
       - id: trailing-whitespace
@@ -20,7 +20,7 @@ repos:
 
 {%- if cookiecutter.repository_enable_conventionalcommit == 'y' %}
   - repo: https://github.com/jorisroovers/gitlint
-    rev: 2ba6564b82c125266091e2571563f7b957aec19c # 0.12.0
+    rev: v0.12.0
     hooks:
       - id: gitlint
         stages:


### PR DESCRIPTION
Change pre-commit revision numbers from git commit sha to
tags to enable automated dependency updating by renovate.